### PR TITLE
Add volume control and frequency readout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gateway Trainer
 
-A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button.
+A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button. The interface now displays the current left and right frequencies and includes a volume slider for finer control.
 
 Open `index.html` in a modern browser to run the trainer.
 

--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,12 @@ body {
   margin: 20px 0;
 }
 
+.sliders label span {
+  display: inline-block;
+  width: 70px;
+  margin-left: 10px;
+}
+
 canvas {
   background: #111;
 }

--- a/index.html
+++ b/index.html
@@ -14,9 +14,11 @@
     <div class="sliders">
       <label>Left Freq
         <input type="range" id="leftFreq" min="50" max="1000" value="200" step="1" />
+        <span id="leftFreqDisplay">200 Hz</span>
       </label>
       <label>Right Offset
         <input type="range" id="offsetFreq" min="-30" max="30" value="5" step="0.1" />
+        <span id="rightFreqDisplay">205 Hz</span>
       </label>
     </div>
 
@@ -39,6 +41,9 @@
       <button id="startBtn">Start</button>
       <button id="stopBtn">Stop</button>
       <button id="bookmarkBtn">🔖 Bookmark</button>
+      <label>Volume
+        <input type="range" id="volume" min="0" max="1" value="0.5" step="0.01" />
+      </label>
     </div>
 
     <div class="visualizers">

--- a/js/audioEngine.js
+++ b/js/audioEngine.js
@@ -7,8 +7,9 @@ let gainNodeL;
 let gainNodeR;
 let analyserL;
 let analyserR;
+let volume = 0.5;
 
-export function startAudio(leftFreq, rightFreq) {
+export function startAudio(leftFreq, rightFreq, vol = 0.5) {
   stopAudio(); // Clean previous
 
   audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -26,14 +27,25 @@ export function startAudio(leftFreq, rightFreq) {
   oscillatorL.frequency.setValueAtTime(leftFreq, audioCtx.currentTime);
   oscillatorR.frequency.setValueAtTime(rightFreq, audioCtx.currentTime);
 
-  gainNodeL.gain.value = 0.5;
-  gainNodeR.gain.value = 0.5;
+  volume = vol;
+  gainNodeL.gain.value = volume;
+  gainNodeR.gain.value = volume;
 
   oscillatorL.connect(gainNodeL).connect(analyserL).connect(audioCtx.destination);
   oscillatorR.connect(gainNodeR).connect(analyserR).connect(audioCtx.destination);
 
   oscillatorL.start();
   oscillatorR.start();
+}
+
+export function setVolume(vol) {
+  volume = vol;
+  if (gainNodeL) gainNodeL.gain.value = volume;
+  if (gainNodeR) gainNodeR.gain.value = volume;
+}
+
+export function getVolume() {
+  return volume;
 }
 
 export function stopAudio() {

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 // File: js/main.js
 
-import { startAudio, stopAudio, setFrequencies, getAnalyserNodes } from './audioEngine.js';
+import { startAudio, stopAudio, setFrequencies, getAnalyserNodes, setVolume } from './audioEngine.js';
 import { applyEffect, setEffect, getEffect, setEffectSpeed } from './effectsEngine.js';
 import { saveBookmark } from './bookmarkManager.js';
 import { initVisualizer } from './visualizer.js';
@@ -12,20 +12,26 @@ const effectSpeedSlider = document.getElementById('effectSpeed');
 const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const bookmarkBtn = document.getElementById('bookmarkBtn');
+const volumeSlider = document.getElementById('volume');
+const leftFreqDisplay = document.getElementById('leftFreqDisplay');
+const rightFreqDisplay = document.getElementById('rightFreqDisplay');
 
 let baseFreq = parseFloat(leftFreqSlider.value);
 let offset = parseFloat(offsetSlider.value);
+leftFreqDisplay.textContent = `${baseFreq} Hz`;
+rightFreqDisplay.textContent = `${baseFreq + offset} Hz`;
 
 leftFreqSlider.oninput = updateFrequencies;
 offsetSlider.oninput = updateFrequencies;
 effectModeSelect.onchange = () => setEffect(effectModeSelect.value);
 effectSpeedSlider.oninput = () => setEffectSpeed(parseFloat(effectSpeedSlider.value));
+volumeSlider.oninput = () => setVolume(parseFloat(volumeSlider.value));
 
 let isPlaying = false;
 
 startBtn.onclick = () => {
   isPlaying = true;
-  startAudio(baseFreq, baseFreq + offset);
+  startAudio(baseFreq, baseFreq + offset, parseFloat(volumeSlider.value));
   const { leftAnalyser, rightAnalyser } = getAnalyserNodes();
   initVisualizer(leftAnalyser, rightAnalyser);
   requestAnimationFrame(updateLoop);
@@ -51,11 +57,15 @@ function updateFrequencies() {
   baseFreq = parseFloat(leftFreqSlider.value);
   offset = parseFloat(offsetSlider.value);
   setFrequencies(baseFreq, baseFreq + offset);
+  leftFreqDisplay.textContent = `${baseFreq} Hz`;
+  rightFreqDisplay.textContent = `${baseFreq + offset} Hz`;
 }
 
 function updateLoop(time) {
   if (!isPlaying) return;
   const [l, r] = applyEffect(getEffect(), baseFreq, baseFreq + offset, time);
   setFrequencies(l, r);
+  leftFreqDisplay.textContent = `${l.toFixed(2)} Hz`;
+  rightFreqDisplay.textContent = `${r.toFixed(2)} Hz`;
   requestAnimationFrame(updateLoop);
 }


### PR DESCRIPTION
## Summary
- display current frequencies next to the sliders
- add a volume slider control
- support volume changes in the audio engine
- update main script to show live frequency values
- document the new controls

## Testing
- `npm test` *(fails: could not read package.json)*
- `bash -n auto_deploy.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a1fe94ebc83248224234f3ca464d8