### PR TITLE
Add Monroe levels and fix effect modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gateway Trainer
 
-A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button. The interface now displays the current left and right frequencies and includes a volume slider for finer control.
+A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button. The interface now displays the current left and right frequencies and includes a volume slider for finer control. A dropdown of Monroe Institute "Focus" levels can automatically set recommended frequencies.
 
 Open `index.html` in a modern browser to run the trainer.
 

--- a/css/style.css
+++ b/css/style.css
@@ -13,6 +13,7 @@ body {
 
 .sliders,
 .effects,
+.levels,
 .controls,
 .visualizers {
   margin: 20px 0;

--- a/index.html
+++ b/index.html
@@ -37,6 +37,20 @@
       </label>
     </div>
 
+    <div class="levels">
+      <label>Monroe Level
+        <select id="monroeLevel">
+          <option value="none">None</option>
+          <option value="focus3">Focus 3</option>
+          <option value="focus10">Focus 10</option>
+          <option value="focus12">Focus 12</option>
+          <option value="focus15">Focus 15</option>
+          <option value="focus21">Focus 21</option>
+          <option value="focus27">Focus 27</option>
+        </select>
+      </label>
+    </div>
+
     <div class="controls">
       <button id="startBtn">Start</button>
       <button id="stopBtn">Stop</button>

--- a/js/effectsEngine.js
+++ b/js/effectsEngine.js
@@ -5,6 +5,12 @@ let effectSpeed = 1.0;
 
 export function applyEffect(effect, leftFreq, rightFreq, time) {
   switch (effect) {
+    case 'sweep':
+      const sweep = Math.sin(time * effectSpeed * 0.001) * 20;
+      return [leftFreq + sweep, rightFreq + sweep];
+    case 'hover':
+      const hover = Math.sin(time * effectSpeed * 0.003) * 3;
+      return [leftFreq + hover, rightFreq - hover];
     case 'wobble':
       const wobble = Math.sin(time * effectSpeed * 0.002) * 2;
       return [leftFreq + wobble, rightFreq - wobble];

--- a/js/main.js
+++ b/js/main.js
@@ -9,12 +9,22 @@ const leftFreqSlider = document.getElementById('leftFreq');
 const offsetSlider = document.getElementById('offsetFreq');
 const effectModeSelect = document.getElementById('effectMode');
 const effectSpeedSlider = document.getElementById('effectSpeed');
+const monroeLevelSelect = document.getElementById('monroeLevel');
 const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const bookmarkBtn = document.getElementById('bookmarkBtn');
 const volumeSlider = document.getElementById('volume');
 const leftFreqDisplay = document.getElementById('leftFreqDisplay');
 const rightFreqDisplay = document.getElementById('rightFreqDisplay');
+
+const monroeLevels = {
+  focus3: { base: 200, offset: 3 },
+  focus10: { base: 200, offset: 10 },
+  focus12: { base: 200, offset: 12 },
+  focus15: { base: 200, offset: 15 },
+  focus21: { base: 200, offset: 21 },
+  focus27: { base: 200, offset: 27 },
+};
 
 let baseFreq = parseFloat(leftFreqSlider.value);
 let offset = parseFloat(offsetSlider.value);
@@ -26,6 +36,13 @@ offsetSlider.oninput = updateFrequencies;
 effectModeSelect.onchange = () => setEffect(effectModeSelect.value);
 effectSpeedSlider.oninput = () => setEffectSpeed(parseFloat(effectSpeedSlider.value));
 volumeSlider.oninput = () => setVolume(parseFloat(volumeSlider.value));
+monroeLevelSelect.onchange = () => {
+  if (monroeLevelSelect.value === 'none') return;
+  const preset = monroeLevels[monroeLevelSelect.value];
+  leftFreqSlider.value = preset.base;
+  offsetSlider.value = preset.offset;
+  updateFrequencies();
+};
 
 let isPlaying = false;
 


### PR DESCRIPTION
## Summary
- implement missing sweep and hover modes
- add Monroe level presets with drop-down selection
- wire presets into main script
- support levels in UI and CSS styles
- document new features

## Testing
- `node --check js/effectsEngine.js`
- `node --check js/main.js`
- `bash -n auto_deploy.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a213d2b5083249ecdf1f15f4eb8cd