### PR TITLE
Fix auto_deploy remote check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Open `index.html` in a modern browser to run the trainer.
 
 ## Auto Deploy Script
 
-The `auto_deploy.sh` script pulls the latest changes from the Git repository and serves the project using Python's built-in HTTP server on port 8000:
+The `auto_deploy.sh` script pulls the latest changes from the Git repository and
+serves the project using the [`serve`](https://www.npmjs.com/package/serve)
+package on port 8000. If the `serve` command is not available, the script will
+install it globally via `npm`:
 
 ```bash
 ./auto_deploy.sh

--- a/auto_deploy.sh
+++ b/auto_deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Auto deploy script
-# Pulls latest changes from the repository and serves the files using a simple
-# HTTP server.
+# Pulls the latest changes from the repository and serves the files using the
+# `serve` package from npm.
 
 set -e
 
@@ -13,14 +13,33 @@ cd "$REPO_DIR"
 # Fetch the latest version of the repository
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     echo "Updating repository..."
-    git pull --ff-only
+    if git remote | grep -q .; then
+        if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
+            git pull --ff-only
+        else
+            echo "No upstream branch set, skipping pull."
+        fi
+    else
+        echo "No git remote configured, skipping pull."
+    fi
 else
     echo "Error: script is not located inside a git repository" >&2
     exit 1
 fi
 
-# Serve the directory on port 8000
+# Serve the directory on port 8000 using the `serve` npm package
 # Press Ctrl+C to stop the server.
 
+# Ensure the `serve` command is available
+if ! command -v serve >/dev/null 2>&1; then
+    echo "'serve' not found. Installing globally with npm..."
+    if command -v npm >/dev/null 2>&1; then
+        npm install -g serve
+    else
+        echo "Error: npm is required but was not found." >&2
+        exit 1
+    fi
+fi
+
 echo "Starting HTTP server on http://localhost:8000"
-python3 -m http.server 8000
+exec serve -l 8000 "$REPO_DIR"


### PR DESCRIPTION
## Summary
- avoid failing when git remote is missing
- skip `git pull` unless an upstream branch exists
- use npm `serve` package to launch the app

## Testing
- `bash -n auto_deploy.sh`
- `bash auto_deploy.sh > /tmp/autodeploy.log &`


------
https://chatgpt.com/codex/tasks/task_e_685ad4486ba483248ecdf5eb946494df