### PR TITLE
Add range controls for hover and sweep effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Gateway Trainer
 
-A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button. The interface now displays the current left and right frequencies and includes a volume slider for finer control. A dropdown of Monroe Institute "Focus" levels can automatically set recommended frequencies.
+A simple browser-based tool for experimenting with binaural beats and basic audio effects. Use the sliders to adjust the base frequency and the frequency offset between the left and right channels. Choose an effect to modulate the tones and save any interesting settings with the bookmark button. The interface now displays the current left and right frequencies and includes a volume slider for finer control. A dropdown of Monroe Institute "Focus" levels can automatically set recommended frequencies. Additional sliders let you tune the range of the **Sweep** and **Hover** effects.
 
 Open `index.html` in a modern browser to run the trainer.
 

--- a/index.html
+++ b/index.html
@@ -35,6 +35,12 @@
       <label>Effect Speed
         <input type="range" id="effectSpeed" min="0.1" max="5" value="1" step="0.1" />
       </label>
+      <label>Sweep Range
+        <input type="range" id="sweepRange" min="0" max="50" value="20" step="1" />
+      </label>
+      <label>Hover Range
+        <input type="range" id="hoverRange" min="0" max="10" value="3" step="0.1" />
+      </label>
     </div>
 
     <div class="levels">

--- a/js/effectsEngine.js
+++ b/js/effectsEngine.js
@@ -2,14 +2,16 @@
 
 let currentEffect = 'none';
 let effectSpeed = 1.0;
+let sweepRange = 20;
+let hoverRange = 3;
 
 export function applyEffect(effect, leftFreq, rightFreq, time) {
   switch (effect) {
     case 'sweep':
-      const sweep = Math.sin(time * effectSpeed * 0.001) * 20;
+      const sweep = Math.sin(time * effectSpeed * 0.001) * sweepRange;
       return [leftFreq + sweep, rightFreq + sweep];
     case 'hover':
-      const hover = Math.sin(time * effectSpeed * 0.003) * 3;
+      const hover = Math.sin(time * effectSpeed * 0.003) * hoverRange;
       return [leftFreq + hover, rightFreq - hover];
     case 'wobble':
       const wobble = Math.sin(time * effectSpeed * 0.002) * 2;
@@ -32,4 +34,12 @@ export function getEffect() {
 
 export function setEffectSpeed(speed) {
   effectSpeed = speed;
+}
+
+export function setSweepRange(range) {
+  sweepRange = range;
+}
+
+export function setHoverRange(range) {
+  hoverRange = range;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 // File: js/main.js
 
 import { startAudio, stopAudio, setFrequencies, getAnalyserNodes, setVolume } from './audioEngine.js';
-import { applyEffect, setEffect, getEffect, setEffectSpeed } from './effectsEngine.js';
+import { applyEffect, setEffect, getEffect, setEffectSpeed, setSweepRange, setHoverRange } from './effectsEngine.js';
 import { saveBookmark } from './bookmarkManager.js';
 import { initVisualizer } from './visualizer.js';
 
@@ -9,6 +9,8 @@ const leftFreqSlider = document.getElementById('leftFreq');
 const offsetSlider = document.getElementById('offsetFreq');
 const effectModeSelect = document.getElementById('effectMode');
 const effectSpeedSlider = document.getElementById('effectSpeed');
+const sweepRangeSlider = document.getElementById('sweepRange');
+const hoverRangeSlider = document.getElementById('hoverRange');
 const monroeLevelSelect = document.getElementById('monroeLevel');
 const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
@@ -28,6 +30,8 @@ const monroeLevels = {
 
 let baseFreq = parseFloat(leftFreqSlider.value);
 let offset = parseFloat(offsetSlider.value);
+setSweepRange(parseFloat(sweepRangeSlider.value));
+setHoverRange(parseFloat(hoverRangeSlider.value));
 leftFreqDisplay.textContent = `${baseFreq} Hz`;
 rightFreqDisplay.textContent = `${baseFreq + offset} Hz`;
 
@@ -35,6 +39,8 @@ leftFreqSlider.oninput = updateFrequencies;
 offsetSlider.oninput = updateFrequencies;
 effectModeSelect.onchange = () => setEffect(effectModeSelect.value);
 effectSpeedSlider.oninput = () => setEffectSpeed(parseFloat(effectSpeedSlider.value));
+sweepRangeSlider.oninput = () => setSweepRange(parseFloat(sweepRangeSlider.value));
+hoverRangeSlider.oninput = () => setHoverRange(parseFloat(hoverRangeSlider.value));
 volumeSlider.oninput = () => setVolume(parseFloat(volumeSlider.value));
 monroeLevelSelect.onchange = () => {
   if (monroeLevelSelect.value === 'none') return;
@@ -66,6 +72,8 @@ bookmarkBtn.onclick = () => {
     offset: parseFloat(offsetSlider.value),
     effect: effectModeSelect.value,
     speed: parseFloat(effectSpeedSlider.value),
+    sweepRange: parseFloat(sweepRangeSlider.value),
+    hoverRange: parseFloat(hoverRangeSlider.value),
   };
   saveBookmark(bookmark);
 };


### PR DESCRIPTION
## Summary
- add Sweep Range and Hover Range sliders
- allow setting ranges in effects engine
- include range settings in bookmarks
- document new controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ad93d53ec832495fd2af999820ccc