### PR TITLE
feat: enable manual frequency entry

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,10 +24,40 @@ body {
   margin: 20px 0;
 }
 
-.sliders label span {
-  display: inline-block;
+.sliders label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sliders label input[type='range'] {
+  flex: 1;
+}
+
+.sliders label span,
+.sliders label .freq-input {
   width: 70px;
-  margin-left: 10px;
+  text-align: center;
+}
+
+.sliders label .freq-input {
+  background: #222;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 4px;
+}
+
+@media (max-width: 480px) {
+  .sliders label {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sliders label span,
+  .sliders label .freq-input {
+    width: 100%;
+    margin-left: 0;
+  }
 }
 
 canvas {

--- a/js/main.js
+++ b/js/main.js
@@ -53,6 +53,57 @@ monroeLevelSelect.onchange = () => {
   updateFrequencies();
 };
 
+function enableManualInput(displayEl, getter, setter) {
+  displayEl.addEventListener('click', () => {
+    const input = document.createElement('input');
+    input.type = 'number';
+    input.className = 'freq-input';
+    input.value = getter().toFixed(2);
+    input.step = '0.01';
+    input.inputMode = 'decimal';
+    displayEl.replaceWith(input);
+    input.focus();
+
+    const commit = () => {
+      const val = parseFloat(input.value);
+      if (!isNaN(val)) {
+        setter(val);
+        updateFrequencies();
+      }
+      input.replaceWith(displayEl);
+    };
+
+    input.addEventListener('blur', commit);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') commit();
+      if (e.key === 'Escape') input.replaceWith(displayEl);
+    });
+  });
+}
+
+enableManualInput(
+  leftFreqDisplay,
+  () => baseFreq,
+  (val) => {
+    const min = parseFloat(leftFreqSlider.min);
+    const max = parseFloat(leftFreqSlider.max);
+    const clamped = Math.min(Math.max(val, min), max);
+    leftFreqSlider.value = clamped;
+  }
+);
+
+enableManualInput(
+  rightFreqDisplay,
+  () => baseFreq + offset,
+  (val) => {
+    const min = parseFloat(offsetSlider.min);
+    const max = parseFloat(offsetSlider.max);
+    let newOffset = val - baseFreq;
+    newOffset = Math.min(Math.max(newOffset, min), max);
+    offsetSlider.value = newOffset;
+  }
+);
+
 let isPlaying = false;
 
 startBtn.onclick = () => {


### PR DESCRIPTION
## Summary
- allow manual left/right frequency edits by clicking the displayed values
- style sliders for responsive layout and add input styling for mobile friendliness

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b73eba2ed08324bf5f6bdbeda9c6d3