### PR TITLE
Add 528 Hz preset checkbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
           <option value="focus27">Focus 27</option>
         </select>
       </label>
+      <label>
+        <input type="checkbox" id="preset528" />
+        528 Hz Preset
+      </label>
     </div>
 
     <div class="controls">

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ const sweepRangeSlider = document.getElementById('sweepRange');
 const hoverRangeSlider = document.getElementById('hoverRange');
 const wobbleRangeSlider = document.getElementById('wobbleRange');
 const monroeLevelSelect = document.getElementById('monroeLevel');
+const preset528Checkbox = document.getElementById('preset528');
 const startBtn = document.getElementById('startBtn');
 const stopBtn = document.getElementById('stopBtn');
 const bookmarkBtn = document.getElementById('bookmarkBtn');
@@ -37,8 +38,14 @@ setWobbleRange(parseFloat(wobbleRangeSlider.value));
 leftFreqDisplay.textContent = `${baseFreq.toFixed(2)} Hz`;
 rightFreqDisplay.textContent = `${(baseFreq + offset).toFixed(2)} Hz`;
 
-leftFreqSlider.oninput = updateFrequencies;
-offsetSlider.oninput = updateFrequencies;
+leftFreqSlider.oninput = () => {
+  preset528Checkbox.checked = false;
+  updateFrequencies();
+};
+offsetSlider.oninput = () => {
+  preset528Checkbox.checked = false;
+  updateFrequencies();
+};
 effectModeSelect.onchange = () => setEffect(effectModeSelect.value);
 effectSpeedSlider.oninput = () => setEffectSpeed(parseFloat(effectSpeedSlider.value));
 sweepRangeSlider.oninput = () => setSweepRange(parseFloat(sweepRangeSlider.value));
@@ -46,11 +53,21 @@ hoverRangeSlider.oninput = () => setHoverRange(parseFloat(hoverRangeSlider.value
 wobbleRangeSlider.oninput = () => setWobbleRange(parseFloat(wobbleRangeSlider.value));
 volumeSlider.oninput = () => setVolume(parseFloat(volumeSlider.value));
 monroeLevelSelect.onchange = () => {
+  preset528Checkbox.checked = false;
   if (monroeLevelSelect.value === 'none') return;
   const preset = monroeLevels[monroeLevelSelect.value];
   leftFreqSlider.value = preset.base;
   offsetSlider.value = preset.offset;
   updateFrequencies();
+};
+
+preset528Checkbox.onchange = () => {
+  if (preset528Checkbox.checked) {
+    monroeLevelSelect.value = 'none';
+    leftFreqSlider.value = 520;
+    offsetSlider.value = 8;
+    updateFrequencies();
+  }
 };
 
 function enableManualInput(displayEl, getter, setter) {


### PR DESCRIPTION
## Summary
- add a UI checkbox that presets frequencies for 528 Hz solfeggio tone
- when enabled, set left to 520 Hz and right to 528 Hz and clear on other adjustments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b742fc9ebc8324ace49386af43e849